### PR TITLE
DB構造初期案

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ wariko.env
 /yarn-error.log
 yarn-debug.log*
 .yarn-integrity
+
+# ignore ER-diagram
+erd.pdf

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ down:
 	docker-compose down
 
 # bundle exec ... のヘルパー
-export command
+export cmd
 .PHONY: be
 be:
-	docker-compose run --rm devserver bundle exec $(command)
+	docker-compose run --rm wariko bundle exec $(cmd)

--- a/app/channels/application_cable/channel.rb
+++ b/app/channels/application_cable/channel.rb
@@ -1,4 +1,0 @@
-module ApplicationCable
-  class Channel < ActionCable::Channel::Base
-  end
-end

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -1,4 +1,0 @@
-module ApplicationCable
-  class Connection < ActionCable::Connection::Base
-  end
-end

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,7 +1,0 @@
-class ApplicationJob < ActiveJob::Base
-  # Automatically retry jobs that encountered a deadlock
-  # retry_on ActiveRecord::Deadlocked
-
-  # Most jobs are safe to ignore if the underlying records are no longer available
-  # discard_on ActiveJob::DeserializationError
-end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,0 @@
-class ApplicationMailer < ActionMailer::Base
-  default from: 'from@example.com'
-  layout 'mailer'
-end

--- a/app/models/discussion.rb
+++ b/app/models/discussion.rb
@@ -1,0 +1,3 @@
+class Discussion < ApplicationRecord
+  belongs_to :payment
+end

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -1,0 +1,4 @@
+class Payment < ApplicationRecord
+  belongs_to :user
+  has_many :discussions
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ApplicationRecord
   # 自己参照
   belongs_to :partner, class_name: 'User', foreign_key: :partner_id, optional: true
+
+  has_many :payments
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,4 @@
+class User < ApplicationRecord
+  # 自己参照
+  belongs_to :partner, class_name: 'User', foreign_key: :partner_id, optional: true
+end

--- a/db/migrate/20190918161610_create_users.rb
+++ b/db/migrate/20190918161610_create_users.rb
@@ -1,0 +1,12 @@
+class CreateUsers < ActiveRecord::Migration[6.0]
+  def change
+    create_table :users do |t|
+      t.string :user_id
+      t.string :nickname
+      t.string :password_digest
+      t.references :partner
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190918161610_create_users.rb
+++ b/db/migrate/20190918161610_create_users.rb
@@ -1,7 +1,7 @@
 class CreateUsers < ActiveRecord::Migration[6.0]
   def change
     create_table :users do |t|
-      t.string :user_id
+      t.string :username
       t.string :nickname
       t.string :password_digest
       t.references :partner

--- a/db/migrate/20190922133301_create_payments.rb
+++ b/db/migrate/20190922133301_create_payments.rb
@@ -1,0 +1,12 @@
+class CreatePayments < ActiveRecord::Migration[6.0]
+  def change
+    create_table :payments do |t|
+      t.integer :value
+      t.text :detail
+      t.string :state
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190922133500_create_discussions.rb
+++ b/db/migrate/20190922133500_create_discussions.rb
@@ -1,0 +1,10 @@
+class CreateDiscussions < ActiveRecord::Migration[6.0]
+  def change
+    create_table :discussions do |t|
+      t.text :content
+      t.references :payment, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20191007204425_rename_column_of_users.rb
+++ b/db/migrate/20191007204425_rename_column_of_users.rb
@@ -1,0 +1,5 @@
+class RenameColumnOfUsers < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :users, :username, :email
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_22_133500) do
+ActiveRecord::Schema.define(version: 2019_10_07_204425) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -34,7 +34,7 @@ ActiveRecord::Schema.define(version: 2019_09_22_133500) do
   end
 
   create_table "users", force: :cascade do |t|
-    t.string "username"
+    t.string "email"
     t.string "nickname"
     t.string "password_digest"
     t.bigint "partner_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,28 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_18_161610) do
+ActiveRecord::Schema.define(version: 2019_09_22_133500) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "discussions", force: :cascade do |t|
+    t.text "content"
+    t.bigint "payment_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["payment_id"], name: "index_discussions_on_payment_id"
+  end
+
+  create_table "payments", force: :cascade do |t|
+    t.integer "value"
+    t.text "detail"
+    t.string "state"
+    t.bigint "user_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_payments_on_user_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "user_id"
@@ -25,4 +43,6 @@ ActiveRecord::Schema.define(version: 2019_09_18_161610) do
     t.index ["partner_id"], name: "index_users_on_partner_id"
   end
 
+  add_foreign_key "discussions", "payments"
+  add_foreign_key "payments", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -34,7 +34,7 @@ ActiveRecord::Schema.define(version: 2019_09_22_133500) do
   end
 
   create_table "users", force: :cascade do |t|
-    t.string "user_id"
+    t.string "username"
     t.string "nickname"
     t.string "password_digest"
     t.bigint "partner_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,28 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `rails
+# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 2019_09_18_161610) do
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "users", force: :cascade do |t|
+    t.string "user_id"
+    t.string "nickname"
+    t.string "password_digest"
+    t.bigint "partner_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["partner_id"], name: "index_users_on_partner_id"
+  end
+
+end

--- a/lib/tasks/auto_generate_diagram.rake
+++ b/lib/tasks/auto_generate_diagram.rake
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+if Rails.env.development?
+  RailsERD.load_tasks
+
+  # TMP Fix for Rails 6.
+  Rake::Task["erd:load_models"].clear
+
+  namespace :erd do
+    task :load_models do
+      say "Loading application environment..."
+      Rake::Task[:environment].invoke
+
+      say "Loading code in search of Active Record models..."
+      Zeitwerk::Loader.eager_load_all
+    end
+  end
+end

--- a/spec/models/discussion_spec.rb
+++ b/spec/models/discussion_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Discussion, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Payment, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/wariko.env.sample
+++ b/wariko.env.sample
@@ -1,3 +1,3 @@
-DB_USERNAME=wariko
-DB_PASSWORD=wariko
+DB_USERNAME=postgres
+DB_PASSWORD=postgres
 DB_HOSTNAME=db


### PR DESCRIPTION
Resolve #1 

### 作ったもの

*User*

- ユーザーの情報を保持しておくモデル(テーブル)
- `partner_id` を通じてこのテーブルにおける別ユーザー(パートナー)を参照させる
  - `User` と `User` に **1対1** の関連付けを与える(自己参照)
- アバター画像を保持するためのカラムを追加するかも?

| id(integer) | username(string) | nickname(string) | password_digest(string) | partner_id(integer) |
|:-:|:-:|:-:|:-:|:-:|
| DBが一意に割り振るID(数字) | ユーザ名(ログイン用の識別子) | 表示名 | パスワードのハッシュ | パートナーの(DBにて一意に割り振られる)ID |

*Payment*

- 請求情報を保持しておくモデル(テーブル)
- `user_id` を通じて `User` と `Payment` に **1対多** の関連付けを与える
 
| id(integer) | value(integer) | detail(text) | state(string) | user_id(integer) |
|:-:|:-:|:-:|:-:|:-:|
| DBが一意に割り振るID | 記録したい金額 | 金額についての詳細 | 請求の状態(後述) | 請求ユーザーのID |

| state | 対応 |
|:-:|:-:|
| pending | 未承認 |
| rejected | 却下 |
| accepted | 確認済 |
| paid | 支払済 |

*Discussion*

- 請求情報に対して議論を行い、それらの内容を保持しておくモデル(テーブル)
- `payment_id` を通じて `Payment` と `Discussion` に **1対多** の関連付けを与える

| id(integer) | content(text) | payment_id(integer) |
|:-----------:|:-------------:|:-------------------:|
| DBが一意に割り振るID | コメント | 議論されている請求のID |

### ER図

*この図に載っていないものもあることに留意*

![image](https://user-images.githubusercontent.com/7458406/65389137-a7643400-dd8d-11e9-9c26-67a1ba43d383.png)
